### PR TITLE
Audio param setup with generics and Any-trait downcasting - do not merge this!

### DIFF
--- a/src/audio_buffer_source_node.rs
+++ b/src/audio_buffer_source_node.rs
@@ -50,14 +50,30 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
     // AudioParams
     let native_clone = native_node.clone();
-    let param_getter = ParamGetter::AudioBufferSourceNodeDetune(native_clone);
+    let param_getter = ParamGetter::new(
+        native_clone,
+        Box::new(|n| {
+            n.as_any()
+                .downcast_ref::<AudioBufferSourceNode>()
+                .unwrap()
+                .detune()
+        }),
+    );
     let napi_param = NapiAudioParam::new(param_getter);
     let mut js_obj = NapiAudioParam::create_js_object(ctx.env)?;
     ctx.env.wrap(&mut js_obj, napi_param)?;
     js_this.set_named_property("detune", &js_obj)?;
 
     let native_clone = native_node.clone();
-    let param_getter = ParamGetter::AudioBufferSourceNodePlaybackRate(native_clone);
+    let param_getter = ParamGetter::new(
+        native_clone,
+        Box::new(|n| {
+            n.as_any()
+                .downcast_ref::<AudioBufferSourceNode>()
+                .unwrap()
+                .playback_rate()
+        }),
+    );
     let napi_param = NapiAudioParam::new(param_getter);
     let mut js_obj = NapiAudioParam::create_js_object(ctx.env)?;
     ctx.env.wrap(&mut js_obj, napi_param)?;

--- a/src/audio_context.rs
+++ b/src/audio_context.rs
@@ -69,7 +69,7 @@ fn sample_rate(ctx: CallContext) -> Result<JsNumber> {
     let napi_obj = ctx.env.unwrap::<NapiAudioContext>(&js_this)?;
     let obj = napi_obj.unwrap();
 
-    let sample_rate = obj.sample_rate().0 as f64;
+    let sample_rate = obj.sample_rate_raw().0 as f64;
     ctx.env.create_double(sample_rate)
 }
 

--- a/src/audio_param.rs
+++ b/src/audio_param.rs
@@ -29,6 +29,21 @@ impl ParamGetter {
 // @note - we can't really create a js class here because ParamGetter must be
 // created by the AudioNode that owns the AudioParam
 // ... but probably we don't care as AudioParam can't be instanciated from JS
+use web_audio_api::node::AudioNode;
+pub(crate) struct ParamGetter2<A, F> {
+    audio_node: Rc<A>,
+    get_param_fn: F,
+}
+impl<A: AudioNode, F: Fn(&A) -> &AudioParam> ParamGetter2<A, F> {
+    pub fn new(audio_node: Rc<A>, get_param_fn: F) -> Self {
+        Self { audio_node, get_param_fn }
+    }
+
+    pub fn get_param(&self) -> &AudioParam {
+        (self.get_param_fn)(self.audio_node.as_ref())
+    }
+}
+
 pub(crate) struct NapiAudioParam(ParamGetter);
 
 impl NapiAudioParam {

--- a/src/gain_node.rs
+++ b/src/gain_node.rs
@@ -6,7 +6,7 @@ use napi_derive::js_function;
 use web_audio_api::node::{AudioNode, GainNode};
 
 use crate::audio_context::NapiAudioContext;
-use crate::audio_param::{NapiAudioParam, ParamGetter};
+use crate::audio_param::{NapiAudioParam, ParamGetter, ParamGetter2};
 
 pub(crate) struct NapiGainNode(Rc<GainNode>);
 
@@ -48,6 +48,12 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     // finalize instance creation
     let napi_node = NapiGainNode(native_node);
     ctx.env.wrap(&mut js_this, napi_node)?;
+  let native_clone = native_node.clone();
+  let param_getter2 = ParamGetter2::new(native_clone, |n| n.gain());
+
+  // finalize instance creation
+  let napi_node = NapiGainNode(native_node);
+  ctx.env.wrap(&mut this, napi_node)?;
 
     ctx.env.get_undefined()
 }

--- a/src/gain_node.rs
+++ b/src/gain_node.rs
@@ -6,7 +6,7 @@ use napi_derive::js_function;
 use web_audio_api::node::{AudioNode, GainNode};
 
 use crate::audio_context::NapiAudioContext;
-use crate::audio_param::{NapiAudioParam, ParamGetter, ParamGetter2};
+use crate::audio_param::{NapiAudioParam, ParamGetter};
 
 pub(crate) struct NapiGainNode(Rc<GainNode>);
 
@@ -39,7 +39,10 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
     // AudioParams
     let native_clone = native_node.clone();
-    let param_getter = ParamGetter::GainNodeGain(native_clone);
+    let param_getter = ParamGetter::new(
+        native_clone,
+        Box::new(|n| n.as_any().downcast_ref::<GainNode>().unwrap().gain()),
+    );
     let napi_param = NapiAudioParam::new(param_getter);
     let mut js_obj = NapiAudioParam::create_js_object(ctx.env)?;
     ctx.env.wrap(&mut js_obj, napi_param)?;
@@ -48,12 +51,6 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
     // finalize instance creation
     let napi_node = NapiGainNode(native_node);
     ctx.env.wrap(&mut js_this, napi_node)?;
-  let native_clone = native_node.clone();
-  let param_getter2 = ParamGetter2::new(native_clone, |n| n.gain());
-
-  // finalize instance creation
-  let napi_node = NapiGainNode(native_node);
-  ctx.env.wrap(&mut this, napi_node)?;
 
     ctx.env.get_undefined()
 }

--- a/src/oscillator_node.rs
+++ b/src/oscillator_node.rs
@@ -45,7 +45,15 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
 
     // AudioParams
     let native_clone = native_node.clone();
-    let param_getter = ParamGetter::OscillatorNodeFrequency(native_clone);
+    let param_getter = ParamGetter::new(
+        native_clone,
+        Box::new(|n| {
+            n.as_any()
+                .downcast_ref::<OscillatorNode>()
+                .unwrap()
+                .frequency()
+        }),
+    );
     let napi_param = NapiAudioParam::new(param_getter);
     let mut js_obj = NapiAudioParam::create_js_object(ctx.env)?;
     ctx.env.wrap(&mut js_obj, napi_param)?;


### PR DESCRIPTION
Hey I tried to follow along with the generics path for the audio params, it was a disaster.
I need to erase the generic params by Boxing them and wrapping them in a special AnyTrait. Otherwise it would not play nicely with napi.
In any case, this is for your entertainment only. Do not merge it, the enum-way is better!